### PR TITLE
fix: keep audit OIDC calls on internal auth URL

### DIFF
--- a/pkg/plugins/audit.go
+++ b/pkg/plugins/audit.go
@@ -1,10 +1,13 @@
 package plugins
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -251,13 +254,18 @@ func (a *Audit) Provision(ctx caddy.Context) error {
 			issuer = a.AuthURL
 		}
 
-		discovery, err := v5client.Discover[v5oidc.DiscoveryConfiguration](ctx, a.AuthURL, httpClient)
+		discovery, err := discoverAuthConfiguration(ctx, a.AuthURL, issuer, httpClient)
 		if err != nil {
 			a.logger.Error("failed to discover oidc configuration", zap.Error(err))
 			return err
 		}
 
-		keySet := v5client.NewRemoteKeySet(httpClient, discovery.JwksURI)
+		jwksURL, err := internalAuthEndpointURL(discovery.JwksURI, issuer, a.AuthURL)
+		if err != nil {
+			return err
+		}
+
+		keySet := v5client.NewRemoteKeySet(httpClient, jwksURL)
 		opts = append(opts, audit.WithAuth(map[string]v5oidc.KeySet{issuer: keySet}))
 	}
 
@@ -267,6 +275,54 @@ func (a *Audit) Provision(ctx caddy.Context) error {
 	)
 
 	return nil
+}
+
+func discoverAuthConfiguration(
+	ctx context.Context,
+	authURL string,
+	issuer string,
+	httpClient *http.Client,
+) (*v5oidc.DiscoveryConfiguration, error) {
+	wellKnownURL := v5oidc.NormalizeIssuer(authURL) + v5oidc.DiscoveryEndpoint
+	return v5client.Discover[v5oidc.DiscoveryConfiguration](ctx, issuer, httpClient, wellKnownURL)
+}
+
+func internalAuthEndpointURL(endpoint string, issuer string, authURL string) (string, error) {
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse discovered auth endpoint url: %w", err)
+	}
+
+	issuerURL, err := url.Parse(v5oidc.NormalizeIssuer(issuer))
+	if err != nil {
+		return "", fmt.Errorf("parse auth issuer url: %w", err)
+	}
+
+	authBaseURL, err := url.Parse(v5oidc.NormalizeIssuer(authURL))
+	if err != nil {
+		return "", fmt.Errorf("parse auth url: %w", err)
+	}
+
+	if endpointURL.Scheme != issuerURL.Scheme ||
+		endpointURL.Host != issuerURL.Host ||
+		!sameOrChildPath(endpointURL.Path, issuerURL.Path) {
+		return endpoint, nil
+	}
+
+	suffix := strings.TrimPrefix(endpointURL.Path, strings.TrimRight(issuerURL.Path, "/"))
+	authBaseURL.Path = strings.TrimRight(authBaseURL.Path, "/") + suffix
+	authBaseURL.RawQuery = endpointURL.RawQuery
+	authBaseURL.Fragment = endpointURL.Fragment
+
+	return authBaseURL.String(), nil
+}
+
+func sameOrChildPath(path string, basePath string) bool {
+	basePath = strings.TrimRight(basePath, "/")
+	if basePath == "" {
+		return strings.HasPrefix(path, "/")
+	}
+	return path == basePath || strings.HasPrefix(path, basePath+"/")
 }
 
 func (a Audit) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {

--- a/pkg/plugins/audit_test.go
+++ b/pkg/plugins/audit_test.go
@@ -1,0 +1,121 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v5oidc "github.com/formancehq/go-libs/v5/pkg/authn/oidc"
+)
+
+func TestDiscoverAuthConfigurationUsesAuthIssuerWithAuthURLDiscovery(t *testing.T) {
+	expectedIssuer := "https://stack.example.test/api/auth"
+	var requestedPath string
+
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(v5oidc.DiscoveryConfiguration{
+			Issuer:  expectedIssuer,
+			JwksURI: expectedIssuer + "/keys",
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer authServer.Close()
+
+	discovery, err := discoverAuthConfiguration(
+		context.Background(),
+		authServer.URL,
+		expectedIssuer,
+		authServer.Client(),
+	)
+	if err != nil {
+		t.Fatalf("discover auth configuration: %v", err)
+	}
+
+	if requestedPath != v5oidc.DiscoveryEndpoint {
+		t.Fatalf("expected discovery request path %q, got %q", v5oidc.DiscoveryEndpoint, requestedPath)
+	}
+	if discovery.Issuer != expectedIssuer {
+		t.Fatalf("expected discovered issuer %q, got %q", expectedIssuer, discovery.Issuer)
+	}
+}
+
+func TestDiscoverAuthConfigurationSupportsAuthURLAsIssuer(t *testing.T) {
+	var authServer *httptest.Server
+	authServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(v5oidc.DiscoveryConfiguration{
+			Issuer:  authServer.URL,
+			JwksURI: authServer.URL + "/keys",
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer authServer.Close()
+
+	discovery, err := discoverAuthConfiguration(
+		context.Background(),
+		authServer.URL,
+		authServer.URL,
+		authServer.Client(),
+	)
+	if err != nil {
+		t.Fatalf("discover auth configuration: %v", err)
+	}
+
+	if discovery.Issuer != authServer.URL {
+		t.Fatalf("expected discovered issuer %q, got %q", authServer.URL, discovery.Issuer)
+	}
+}
+
+func TestInternalAuthEndpointURLRewritesIssuerEndpointToAuthURL(t *testing.T) {
+	got, err := internalAuthEndpointURL(
+		"https://stack.example.test/api/auth/keys",
+		"https://stack.example.test/api/auth",
+		"http://auth:8080",
+	)
+	if err != nil {
+		t.Fatalf("rewrite auth endpoint url: %v", err)
+	}
+
+	if got != "http://auth:8080/keys" {
+		t.Fatalf("expected internal jwks url %q, got %q", "http://auth:8080/keys", got)
+	}
+}
+
+func TestInternalAuthEndpointURLPreservesAuthURLPath(t *testing.T) {
+	got, err := internalAuthEndpointURL(
+		"https://stack.example.test/api/auth/keys",
+		"https://stack.example.test/api/auth",
+		"http://gateway:8080/api/auth",
+	)
+	if err != nil {
+		t.Fatalf("rewrite auth endpoint url: %v", err)
+	}
+
+	if got != "http://gateway:8080/api/auth/keys" {
+		t.Fatalf("expected internal jwks url %q, got %q", "http://gateway:8080/api/auth/keys", got)
+	}
+}
+
+func TestInternalAuthEndpointURLKeepsExternalEndpointWhenNotUnderIssuer(t *testing.T) {
+	endpoint := "https://keys.example.test/jwks"
+	got, err := internalAuthEndpointURL(
+		endpoint,
+		"https://stack.example.test/api/auth",
+		"http://auth:8080",
+	)
+	if err != nil {
+		t.Fatalf("rewrite auth endpoint url: %v", err)
+	}
+
+	if got != endpoint {
+		t.Fatalf("expected endpoint %q, got %q", endpoint, got)
+	}
+}


### PR DESCRIPTION
## What changed

- Use `auth_issuer` as the expected OIDC issuer during audit provider discovery.
- Keep discovery traffic on `auth_url` by passing the internal well-known endpoint as an override.
- Rewrite issuer-scoped discovered endpoints, currently JWKS, back onto `auth_url` so key fetching also stays on the private Kubernetes network.
- Add unit coverage for split `auth_url` / `auth_issuer` deployments and the legacy same-URL case.

## Why

Gateway v2.3.0 uses go-libs v5 discovery, which validates that the discovered issuer matches the issuer passed to discovery. Operator-managed stacks configure Auth with a public issuer while the gateway reaches Auth through an internal Kubernetes URL. Passing `auth_url` as the issuer caused startup failures like:

```text
issuer does not match: Expected: http://auth:8080, got: https://.../api/auth
```

## Impact

This preserves the intended deployment model: tokens are validated against the public issuer, while gateway-to-auth discovery and JWKS calls remain private inside the cluster.

## Validation

```text
go test ./...
go build ./...
go mod tidy
go test -tags it ./test/e2e
```